### PR TITLE
escape dollars in vault files

### DIFF
--- a/lib/core
+++ b/lib/core
@@ -113,7 +113,7 @@ pass_cache () {
         _value="$(${PASS_BIN} "${_key}" 2>/dev/null)"
         if [ -n "${_value}" ]; then
             mkdir -p "${DEFAULT_CACHE_FACTS_DIR}"
-            echo "${_cache_name}=\"${_value}\"" | ${SED_BIN} 's/\n/\\ \n/g' 2>/dev/null > "${_cache_file}"
+            echo "${_cache_name}=\"${_value}\"" | ${SED_BIN} 's/\$/\\\$/g' | ${SED_BIN} 's/\n/\\ \n/g' 2>/dev/null > "${_cache_file}"
             echo "${_value}"
         fi
     }


### PR DESCRIPTION
so they are not interpreted by the double quotes in the cache files later. 
usecase: Allows to stores things like PHP config files in the vault and read them later on without issues