### PR TITLE
Support facts with =/&/? inside the value

### DIFF
--- a/lib/shable
+++ b/lib/shable
@@ -620,7 +620,7 @@ facts_write () {
     else
         test -d "facts/cached" || mkdir -p "facts/cached"
         for _fact in ${*}; do
-            _fname="${_fact%=*}.facts"
+            _fname="${_fact%%=*}.facts"
             _fdest="facts/cached/${_fname}"
             echo "${_fact}" > "${_fdest}"
             debug "Stored fact: $(distd "${_fact}") under: $(distd "${_fdest}")"

--- a/lib/shable
+++ b/lib/shable
@@ -133,7 +133,11 @@ template () {
 
     for _arg in ${_args}; do
         _key="$(echo "${_arg}" | ${SED_BIN} 's/=.*//' 2>/dev/null | ${SED_BIN} -e 's/[]\/$*.^[]/\\&/g' 2>/dev/null)"
-        _val="$(echo "${_arg}" | ${SED_BIN} -E 's/[^=]+=//' 2>/dev/null | ${SED_BIN} -e 's/[\/&]/\\&/g'  2>/dev/null)"
+        # escape &\ for sed-replace
+        # and remove quoted (needed due to eval above which breaks if value contains &)
+        _val="$(echo "${_arg}" | ${SED_BIN} -E 's/[^=]+=//' 2>/dev/null | \
+            ${SED_BIN} -e 's/[\/&]/\\&/g' 2>/dev/null | \
+            ${SED_BIN} -e "s/^'\(.*\)'$/\1/" 2>/dev/null)"
         case "${SYSTEM_NAME}" in
             Darwin|FreeBSD)
                 ${SED_BIN} -i '' -e "s#{{ *${_key} *}}#${_val}#g;" "${dest}"

--- a/lib/shable
+++ b/lib/shable
@@ -132,8 +132,8 @@ template () {
         "${dest}"
 
     for _arg in ${_args}; do
-        _key="$(echo "${_arg}" | ${SED_BIN} 's/=.*//' 2>/dev/null)"
-        _val="$(echo "${_arg}" | ${SED_BIN} 's/.*=//' 2>/dev/null)"
+        _key="$(echo "${_arg}" | ${SED_BIN} 's/=.*//' 2>/dev/null | ${SED_BIN} -e 's/[]\/$*.^[]/\\&/g' 2>/dev/null)"
+        _val="$(echo "${_arg}" | ${SED_BIN} -E 's/[^=]+=//' 2>/dev/null | ${SED_BIN} -e 's/[\/&]/\\&/g'  2>/dev/null)"
         case "${SYSTEM_NAME}" in
             Darwin|FreeBSD)
                 ${SED_BIN} -i '' -e "s#{{ *${_key} *}}#${_val}#g;" "${dest}"


### PR DESCRIPTION
Uses %% (deletes the longest possible match from the right) instead of % (deletes the shortest possible match from the right)

Example:
Before:
```
_fact="hej=ok=ja=ok=ne"
echo "_fname=${_fact%=*}"
# outputs: _fname=hej=ok=ja=ok
```
After:
```
_fact="hej=ok=ja=ok=ne"
echo "_fname=${_fact%%=*}"
# outputs: _fname=hej
```

Also template()-function is changed to escape `&` in value for `sed`-replace.

And, `eval` now runs in `template()`, this now needs arguments that contains `&` to wrap them in quotes:
```
    template \
        src="src" \
        dest="dest" \
        url="'${url}'"
```
But later on it's being looped through for the actual replacement, and here we need to remove those quotes.